### PR TITLE
Avoid useless parallel section

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -60,7 +60,6 @@ main(int argc, char **argv) {
     }
 
     if (args.useOpenMp)
-        
         slog_info(4, "Using %d threads", omp_get_max_threads());
 
     if (args.outputFormat == CSV) {

--- a/src/main.c
+++ b/src/main.c
@@ -60,11 +60,8 @@ main(int argc, char **argv) {
     }
 
     if (args.useOpenMp)
-        #pragma omp parallel
-        {
-            #pragma omp single
-            slog_info(4, "Using %d threads", omp_get_num_threads());
-        }
+        
+        slog_info(4, "Using %d threads", omp_get_max_threads());
 
     if (args.outputFormat == CSV) {
         printCSVHeader();


### PR DESCRIPTION
You are creating a parallel region (with the overhead of creating the threads) to check the maximum number of threads available.

A better approach is to just use `omp_get_max_threads` to get the maximum number of exploitable threads.